### PR TITLE
Add WPF CRUD pages

### DIFF
--- a/src/Gym.Client/ApiClient.cs
+++ b/src/Gym.Client/ApiClient.cs
@@ -1,0 +1,48 @@
+using System.Net.Http;
+using System.Net.Http.Json;
+using Gym.Client.Models;
+
+namespace Gym.Client;
+
+public class ApiClient
+{
+    private readonly HttpClient _http;
+    public ApiClient(string baseUrl)
+    {
+        _http = new HttpClient { BaseAddress = new(baseUrl) };
+    }
+
+    public Task<List<MemberDto>?> GetMembersAsync() =>
+        _http.GetFromJsonAsync<List<MemberDto>>("api/members");
+
+    public async Task<MemberDto?> AddMemberAsync(MemberDto dto)
+    {
+        var resp = await _http.PostAsJsonAsync("api/members", dto);
+        return await resp.Content.ReadFromJsonAsync<MemberDto>();
+    }
+
+    public async Task<MemberDto?> UpdateMemberAsync(MemberDto dto)
+    {
+        var resp = await _http.PutAsJsonAsync($"api/members/{dto.Id}", dto);
+        return await resp.Content.ReadFromJsonAsync<MemberDto>();
+    }
+
+    public Task DeleteMemberAsync(long id) => _http.DeleteAsync($"api/members/{id}");
+
+    public Task<List<PlanDto>?> GetPlansAsync() =>
+        _http.GetFromJsonAsync<List<PlanDto>>("api/plans");
+
+    public async Task<PlanDto?> AddPlanAsync(PlanDto dto)
+    {
+        var resp = await _http.PostAsJsonAsync("api/plans", dto);
+        return await resp.Content.ReadFromJsonAsync<PlanDto>();
+    }
+
+    public async Task<PlanDto?> UpdatePlanAsync(PlanDto dto)
+    {
+        var resp = await _http.PutAsJsonAsync($"api/plans/{dto.Id}", dto);
+        return await resp.Content.ReadFromJsonAsync<PlanDto>();
+    }
+
+    public Task DeletePlanAsync(int id) => _http.DeleteAsync($"api/plans/{id}");
+}

--- a/src/Gym.Client/Dialogs/MemberEditWindow.xaml
+++ b/src/Gym.Client/Dialogs/MemberEditWindow.xaml
@@ -1,0 +1,33 @@
+<Window x:Class="Gym.Client.Dialogs.MemberEditWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Member" Height="300" Width="400">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <TextBlock Text="First Name:" Grid.Row="0" Grid.Column="0" Margin="5"/>
+        <TextBox Text="{Binding FirstName}" Grid.Row="0" Grid.Column="1" Margin="5"/>
+        <TextBlock Text="Last Name:" Grid.Row="1" Grid.Column="0" Margin="5"/>
+        <TextBox Text="{Binding LastName}" Grid.Row="1" Grid.Column="1" Margin="5"/>
+        <TextBlock Text="Email:" Grid.Row="2" Grid.Column="0" Margin="5"/>
+        <TextBox Text="{Binding Email}" Grid.Row="2" Grid.Column="1" Margin="5"/>
+        <TextBlock Text="Phone:" Grid.Row="3" Grid.Column="0" Margin="5"/>
+        <TextBox Text="{Binding Phone}" Grid.Row="3" Grid.Column="1" Margin="5"/>
+        <CheckBox Content="KYC Complete" IsChecked="{Binding KycComplete}" Grid.Row="4" Grid.Column="1" Margin="5"/>
+        <StackPanel Orientation="Horizontal" Grid.Row="5" Grid.ColumnSpan="2" HorizontalAlignment="Right">
+            <Button Content="OK" Width="80" Margin="5" IsDefault="True" Click="Ok_Click"/>
+            <Button Content="Cancel" Width="80" Margin="5" IsCancel="True"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/Gym.Client/Dialogs/MemberEditWindow.xaml.cs
+++ b/src/Gym.Client/Dialogs/MemberEditWindow.xaml.cs
@@ -1,0 +1,21 @@
+using System.Windows;
+using Gym.Client.Models;
+
+namespace Gym.Client.Dialogs;
+
+public partial class MemberEditWindow : Window
+{
+    public MemberDto Model { get; private set; }
+
+    public MemberEditWindow(MemberDto? model)
+    {
+        InitializeComponent();
+        Model = model ?? new MemberDto(0, "", "", "", null, null, null, false, DateTime.Now, DateTime.Now);
+        DataContext = Model;
+    }
+
+    private void Ok_Click(object sender, RoutedEventArgs e)
+    {
+        DialogResult = true;
+    }
+}

--- a/src/Gym.Client/Dialogs/PlanEditWindow.xaml
+++ b/src/Gym.Client/Dialogs/PlanEditWindow.xaml
@@ -1,0 +1,35 @@
+<Window x:Class="Gym.Client.Dialogs.PlanEditWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Plan" Height="300" Width="400">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <TextBlock Text="Name:" Grid.Row="0" Grid.Column="0" Margin="5"/>
+        <TextBox Text="{Binding Name}" Grid.Row="0" Grid.Column="1" Margin="5"/>
+        <TextBlock Text="Description:" Grid.Row="1" Grid.Column="0" Margin="5"/>
+        <TextBox Text="{Binding Description}" Grid.Row="1" Grid.Column="1" Margin="5"/>
+        <TextBlock Text="Price (cents):" Grid.Row="2" Grid.Column="0" Margin="5"/>
+        <TextBox Text="{Binding PriceCents}" Grid.Row="2" Grid.Column="1" Margin="5"/>
+        <TextBlock Text="Duration (months):" Grid.Row="3" Grid.Column="0" Margin="5"/>
+        <TextBox Text="{Binding DurationMonths}" Grid.Row="3" Grid.Column="1" Margin="5"/>
+        <TextBlock Text="Grace Days:" Grid.Row="4" Grid.Column="0" Margin="5"/>
+        <TextBox Text="{Binding GraceDays}" Grid.Row="4" Grid.Column="1" Margin="5"/>
+        <CheckBox Content="Is Active" IsChecked="{Binding IsActive}" Grid.Row="5" Grid.Column="1" Margin="5"/>
+        <StackPanel Orientation="Horizontal" Grid.Row="6" Grid.ColumnSpan="2" HorizontalAlignment="Right">
+            <Button Content="OK" Width="80" Margin="5" IsDefault="True" Click="Ok_Click"/>
+            <Button Content="Cancel" Width="80" Margin="5" IsCancel="True"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/Gym.Client/Dialogs/PlanEditWindow.xaml.cs
+++ b/src/Gym.Client/Dialogs/PlanEditWindow.xaml.cs
@@ -1,0 +1,21 @@
+using System.Windows;
+using Gym.Client.Models;
+
+namespace Gym.Client.Dialogs;
+
+public partial class PlanEditWindow : Window
+{
+    public PlanDto Model { get; private set; }
+
+    public PlanEditWindow(PlanDto? model)
+    {
+        InitializeComponent();
+        Model = model ?? new PlanDto(0, "", null, 0, 1, 0, true, DateTime.Now, DateTime.Now);
+        DataContext = Model;
+    }
+
+    private void Ok_Click(object sender, RoutedEventArgs e)
+    {
+        DialogResult = true;
+    }
+}

--- a/src/Gym.Client/MainWindow.xaml
+++ b/src/Gym.Client/MainWindow.xaml
@@ -1,12 +1,16 @@
-﻿<Window x:Class="Gym.Client.MainWindow"
+<Window x:Class="Gym.Client.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Gym.Client"
         mc:Ignorable="d"
-        Title="MainWindow" Height="450" Width="800">
-    <Grid>
-
-    </Grid>
+        Title="Gym Client" Height="450" Width="800">
+    <DockPanel>
+        <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Background="LightGray" Margin="5">
+            <Button Content="Members" Click="Members_Click" Margin="2"/>
+            <Button Content="Plans" Click="Plans_Click" Margin="2"/>
+        </StackPanel>
+        <Frame x:Name="MainFrame"/>
+    </DockPanel>
 </Window>

--- a/src/Gym.Client/MainWindow.xaml.cs
+++ b/src/Gym.Client/MainWindow.xaml.cs
@@ -1,23 +1,24 @@
-﻿using System.Text;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+using Gym.Client.Pages;
 
 namespace Gym.Client;
 
-/// <summary>
-/// Interaction logic for MainWindow.xaml
-/// </summary>
 public partial class MainWindow : Window
 {
+    private readonly ApiClient _api = new("http://localhost:5000/");
+
     public MainWindow()
     {
         InitializeComponent();
+    }
+
+    private void Members_Click(object sender, RoutedEventArgs e)
+    {
+        MainFrame.Content = new MembersPage(_api);
+    }
+
+    private void Plans_Click(object sender, RoutedEventArgs e)
+    {
+        MainFrame.Content = new PlansPage(_api);
     }
 }

--- a/src/Gym.Client/Models/MemberDto.cs
+++ b/src/Gym.Client/Models/MemberDto.cs
@@ -1,0 +1,13 @@
+namespace Gym.Client.Models;
+
+public record MemberDto(
+    long Id,
+    string FirstName,
+    string LastName,
+    string Email,
+    string? Phone,
+    DateOnly? DateOfBirth,
+    string? IdScanPath,
+    bool KycComplete,
+    DateTime CreatedAt,
+    DateTime UpdatedAt);

--- a/src/Gym.Client/Models/PlanDto.cs
+++ b/src/Gym.Client/Models/PlanDto.cs
@@ -1,0 +1,12 @@
+namespace Gym.Client.Models;
+
+public record PlanDto(
+    int Id,
+    string Name,
+    string? Description,
+    int PriceCents,
+    byte DurationMonths,
+    byte GraceDays,
+    bool IsActive,
+    DateTime CreatedAt,
+    DateTime UpdatedAt);

--- a/src/Gym.Client/Pages/MembersPage.xaml
+++ b/src/Gym.Client/Pages/MembersPage.xaml
@@ -1,0 +1,17 @@
+<Page x:Class="Gym.Client.Pages.MembersPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      mc:Ignorable="d"
+      Title="Members">
+    <DockPanel>
+        <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="5">
+            <Button Content="Refresh" Click="Refresh_Click" Margin="2" />
+            <Button Content="Add" Click="Add_Click" Margin="2" />
+            <Button Content="Edit" Click="Edit_Click" Margin="2" />
+            <Button Content="Delete" Click="Delete_Click" Margin="2" />
+        </StackPanel>
+        <DataGrid x:Name="Grid" Margin="5" AutoGenerateColumns="True"/>
+    </DockPanel>
+</Page>

--- a/src/Gym.Client/Pages/MembersPage.xaml.cs
+++ b/src/Gym.Client/Pages/MembersPage.xaml.cs
@@ -1,0 +1,62 @@
+using System.Collections.ObjectModel;
+using System.Windows;
+using System.Windows.Controls;
+using Gym.Client.Models;
+
+using Gym.Client.Dialogs;
+namespace Gym.Client.Pages;
+
+public partial class MembersPage : Page
+{
+    private readonly ApiClient _api;
+    public ObservableCollection<MemberDto> Items { get; } = new();
+
+    public MembersPage(ApiClient api)
+    {
+        InitializeComponent();
+        _api = api;
+        Grid.ItemsSource = Items;
+    }
+
+    private async void Refresh_Click(object sender, RoutedEventArgs e)
+    {
+        Items.Clear();
+        var data = await _api.GetMembersAsync() ?? new List<MemberDto>();
+        foreach (var m in data) Items.Add(m);
+    }
+
+    private async void Add_Click(object sender, RoutedEventArgs e)
+    {
+        var dlg = new MemberEditWindow(null);
+        if (dlg.ShowDialog() == true)
+        {
+            var added = await _api.AddMemberAsync(dlg.Model);
+            if (added is not null) Items.Add(added);
+        }
+    }
+
+    private async void Edit_Click(object sender, RoutedEventArgs e)
+    {
+        if (Grid.SelectedItem is not MemberDto dto) return;
+        var dlg = new MemberEditWindow(dto);
+        if (dlg.ShowDialog() == true)
+        {
+            var updated = await _api.UpdateMemberAsync(dlg.Model);
+            if (updated is not null)
+            {
+                var index = Items.IndexOf(dto);
+                Items[index] = updated;
+            }
+        }
+    }
+
+    private async void Delete_Click(object sender, RoutedEventArgs e)
+    {
+        if (Grid.SelectedItem is not MemberDto dto) return;
+        if (MessageBox.Show($"Delete {dto.FirstName}?", "Confirm", MessageBoxButton.YesNo) == MessageBoxResult.Yes)
+        {
+            await _api.DeleteMemberAsync(dto.Id);
+            Items.Remove(dto);
+        }
+    }
+}

--- a/src/Gym.Client/Pages/PlansPage.xaml
+++ b/src/Gym.Client/Pages/PlansPage.xaml
@@ -1,0 +1,17 @@
+<Page x:Class="Gym.Client.Pages.PlansPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      mc:Ignorable="d"
+      Title="Plans">
+    <DockPanel>
+        <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="5">
+            <Button Content="Refresh" Click="Refresh_Click" Margin="2" />
+            <Button Content="Add" Click="Add_Click" Margin="2" />
+            <Button Content="Edit" Click="Edit_Click" Margin="2" />
+            <Button Content="Delete" Click="Delete_Click" Margin="2" />
+        </StackPanel>
+        <DataGrid x:Name="Grid" Margin="5" AutoGenerateColumns="True"/>
+    </DockPanel>
+</Page>

--- a/src/Gym.Client/Pages/PlansPage.xaml.cs
+++ b/src/Gym.Client/Pages/PlansPage.xaml.cs
@@ -1,0 +1,62 @@
+using System.Collections.ObjectModel;
+using System.Windows;
+using System.Windows.Controls;
+using Gym.Client.Models;
+
+using Gym.Client.Dialogs;
+namespace Gym.Client.Pages;
+
+public partial class PlansPage : Page
+{
+    private readonly ApiClient _api;
+    public ObservableCollection<PlanDto> Items { get; } = new();
+
+    public PlansPage(ApiClient api)
+    {
+        InitializeComponent();
+        _api = api;
+        Grid.ItemsSource = Items;
+    }
+
+    private async void Refresh_Click(object sender, RoutedEventArgs e)
+    {
+        Items.Clear();
+        var data = await _api.GetPlansAsync() ?? new List<PlanDto>();
+        foreach (var m in data) Items.Add(m);
+    }
+
+    private async void Add_Click(object sender, RoutedEventArgs e)
+    {
+        var dlg = new PlanEditWindow(null);
+        if (dlg.ShowDialog() == true)
+        {
+            var added = await _api.AddPlanAsync(dlg.Model);
+            if (added is not null) Items.Add(added);
+        }
+    }
+
+    private async void Edit_Click(object sender, RoutedEventArgs e)
+    {
+        if (Grid.SelectedItem is not PlanDto dto) return;
+        var dlg = new PlanEditWindow(dto);
+        if (dlg.ShowDialog() == true)
+        {
+            var updated = await _api.UpdatePlanAsync(dlg.Model);
+            if (updated is not null)
+            {
+                var index = Items.IndexOf(dto);
+                Items[index] = updated;
+            }
+        }
+    }
+
+    private async void Delete_Click(object sender, RoutedEventArgs e)
+    {
+        if (Grid.SelectedItem is not PlanDto dto) return;
+        if (MessageBox.Show($"Delete {dto.Name}?", "Confirm", MessageBoxButton.YesNo) == MessageBoxResult.Yes)
+        {
+            await _api.DeletePlanAsync(dto.Id);
+            Items.Remove(dto);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add DTO models and API client to call backend
- create member and plan listing pages
- add edit windows for members and plans
- update main window to navigate between pages

## Testing
- `dotnet build GymAccess.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872cbe066c08325b5acfeaf38b9bd1d