### PR TITLE
Fix missing authorization services

### DIFF
--- a/src/Gym.Api/Program.cs
+++ b/src/Gym.Api/Program.cs
@@ -31,6 +31,8 @@ builder.Services.AddRepositories();
 builder.Services.AddServices();
 builder.Services.AddHostedService<BackupService>();
 
+builder.Services.AddAuthorization();
+
 builder.Services.AddAutoMapper(typeof(Program));
 
 builder.Services.AddEndpointsApiExplorer();


### PR DESCRIPTION
## Summary
- add `AddAuthorization()` during startup to register authorization services

## Testing
- `dotnet format --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872ed41cb8c83258e8e6a4ef833ffc8