### PR TITLE
Improve auth flow with signup and better UI

### DIFF
--- a/src/Gym.Api/Data/GymContext.cs
+++ b/src/Gym.Api/Data/GymContext.cs
@@ -27,6 +27,7 @@ public class GymContext(DbContextOptions<GymContext> opts) : DbContext(opts)
         {
             e.ToTable("members");
             e.HasKey(m => m.MemberId);
+            e.Property(m => m.MemberId).HasColumnName("member_id");
             e.Property(m => m.FirstName).HasColumnName("first_name");
             e.Property(m => m.LastName).HasColumnName("last_name");
             e.Property(m => m.Email).HasColumnName("email");
@@ -41,6 +42,7 @@ public class GymContext(DbContextOptions<GymContext> opts) : DbContext(opts)
         {
             e.ToTable("plans");
             e.HasKey(p => p.PlanId);
+            e.Property(p => p.PlanId).HasColumnName("plan_id");
             e.Property(p => p.Name).HasColumnName("name");
             e.Property(p => p.Description).HasColumnName("description");
             e.Property(p => p.PriceCents).HasColumnName("price_cents");
@@ -66,6 +68,7 @@ public class GymContext(DbContextOptions<GymContext> opts) : DbContext(opts)
         {
             e.ToTable("fingerprints");
             e.HasKey(f => f.FingerprintId);
+            e.Property(f => f.FingerprintId).HasColumnName("fingerprint_id");
             e.Property(f => f.MemberId).HasColumnName("member_id");
             e.Property(f => f.FingerLabel).HasColumnName("finger_label").HasConversion<string>();
             e.Property(f => f.TemplateBlob).HasColumnName("template_blob");
@@ -76,6 +79,7 @@ public class GymContext(DbContextOptions<GymContext> opts) : DbContext(opts)
         {
             e.ToTable("subscriptions");
             e.HasKey(s => s.SubscriptionId);
+            e.Property(s => s.SubscriptionId).HasColumnName("subscription_id");
             e.Property(s => s.MemberId).HasColumnName("member_id");
             e.Property(s => s.PlanId).HasColumnName("plan_id");
             e.Property(s => s.StartDate).HasColumnName("start_date");
@@ -88,6 +92,7 @@ public class GymContext(DbContextOptions<GymContext> opts) : DbContext(opts)
         {
             e.ToTable("payments");
             e.HasKey(p => p.PaymentId);
+            e.Property(p => p.PaymentId).HasColumnName("payment_id");
             e.Property(p => p.SubscriptionId).HasColumnName("subscription_id");
             e.Property(p => p.AmountCents).HasColumnName("amount_cents");
             e.Property(p => p.PaidOn).HasColumnName("paid_on");
@@ -100,6 +105,7 @@ public class GymContext(DbContextOptions<GymContext> opts) : DbContext(opts)
         {
             e.ToTable("controllers");
             e.HasKey(c => c.ControllerId);
+            e.Property(c => c.ControllerId).HasColumnName("controller_id");
             e.Property(c => c.Name).HasColumnName("name");
             e.Property(c => c.IpAddress).HasColumnName("ip_address");
             e.Property(c => c.FirmwareVersion).HasColumnName("firmware_version");
@@ -109,6 +115,7 @@ public class GymContext(DbContextOptions<GymContext> opts) : DbContext(opts)
         {
             e.ToTable("access_tokens");
             e.HasKey(t => t.TokenId);
+            e.Property(t => t.TokenId).HasColumnName("token_id");
             e.Property(t => t.MemberId).HasColumnName("member_id");
             e.Property(t => t.TokenValue).HasColumnName("token_value");
             e.Property(t => t.IssuedAt).HasColumnName("issued_at");
@@ -128,6 +135,7 @@ public class GymContext(DbContextOptions<GymContext> opts) : DbContext(opts)
         {
             e.ToTable("access_logs");
             e.HasKey(l => l.LogId);
+            e.Property(l => l.LogId).HasColumnName("log_id");
             e.Property(l => l.ControllerId).HasColumnName("controller_id");
             e.Property(l => l.MemberId).HasColumnName("member_id");
             e.Property(l => l.EventType).HasColumnName("event_type").HasConversion<string>();
@@ -138,6 +146,7 @@ public class GymContext(DbContextOptions<GymContext> opts) : DbContext(opts)
         {
             e.ToTable("email_alerts");
             e.HasKey(a => a.AlertId);
+            e.Property(a => a.AlertId).HasColumnName("alert_id");
             e.Property(a => a.AlertType).HasColumnName("alert_type").HasConversion<string>();
             e.Property(a => a.RelatedMember).HasColumnName("related_member");
             e.Property(a => a.Details).HasColumnName("details");

--- a/src/Gym.Api/Endpoints/AlertEndpoints.cs
+++ b/src/Gym.Api/Endpoints/AlertEndpoints.cs
@@ -10,7 +10,8 @@ public static class AlertEndpoints
 {
     public static RouteGroupBuilder MapAlertEndpoints(this RouteGroupBuilder g)
     {
-        var group = g.MapGroup("alerts").RequireAuthorization(Roles.ADMIN);
+        var group = g.MapGroup("alerts")
+            .RequireAuthorization(p => p.RequireRole(Roles.ADMIN));
         group.MapGet("", async (IAlertService svc) => Results.Ok(await svc.All()));
         return g;
     }

--- a/src/Gym.Api/Endpoints/AuthEndpoints.cs
+++ b/src/Gym.Api/Endpoints/AuthEndpoints.cs
@@ -3,7 +3,6 @@
 // File: Endpoints/AuthEndpoints.cs (unchanged)
 // =============================
 using Gym.Api.Auth;
-using Microsoft.AspNetCore.Cryptography.KeyDerivation;
 using System.Security.Claims;
 using Gym.Api.Data;
 using Gym.Api.Models;
@@ -17,9 +16,9 @@ public static class AuthEndpoints
     {
         g.MapPost("auth/login", async (LoginRequest req, GymContext db, ITokenService tok) =>
         {
-            string hash = Hash(req.Password);
-            var user = await db.AppUsers.FirstOrDefaultAsync(u => u.Username == req.Username && u.PasswordHash == hash);
-            if (user is null) return Results.Unauthorized();
+            var user = await db.AppUsers.FirstOrDefaultAsync(u => u.Username == req.Username);
+            if (user is null || !BCrypt.Net.BCrypt.Verify(req.Password, user.PasswordHash))
+                return Results.Unauthorized();
 
             var claims = new[]
             {
@@ -32,10 +31,27 @@ public static class AuthEndpoints
             // TODO: persist refresh token & expiry
             return Results.Ok(new { access, refresh });
         }).AllowAnonymous();
+
+        g.MapPost("auth/signup", async (SignupRequest req, GymContext db) =>
+        {
+            if (await db.AppUsers.AnyAsync(u => u.Username == req.Username))
+                return Results.BadRequest("Username already exists");
+            var user = new AppUser
+            {
+                Username = req.Username,
+                Email = req.Email,
+                PasswordHash = BCrypt.Net.BCrypt.HashPassword(req.Password),
+                Role = UserRole.DATA_ENTRY,
+                IsEnabled = true,
+                CreatedAt = DateTime.UtcNow
+            };
+            db.AppUsers.Add(user);
+            await db.SaveChangesAsync();
+            return Results.Created($"/api/users/{user.UserId}", new { user.UserId, user.Username });
+        }).AllowAnonymous();
         return g;
     }
 
-    private static string Hash(string pwd) => Convert.ToHexString(KeyDerivation.Pbkdf2(pwd, new byte[16], KeyDerivationPrf.HMACSHA256, 600000, 32));
-
     public record LoginRequest(string Username, string Password);
+    public record SignupRequest(string Username, string Email, string Password);
 }

--- a/src/Gym.Api/Endpoints/AuthEndpoints.cs
+++ b/src/Gym.Api/Endpoints/AuthEndpoints.cs
@@ -18,7 +18,7 @@ public static class AuthEndpoints
         {
             var user = await db.AppUsers.FirstOrDefaultAsync(u => u.Username == req.Username);
             if (user is null || !BCrypt.Net.BCrypt.Verify(req.Password, user.PasswordHash))
-                return Results.Unauthorized();
+                return Results.Json("Invalid username or password", statusCode: 401);
 
             var claims = new[]
             {

--- a/src/Gym.Api/Endpoints/LogEndpoints.cs
+++ b/src/Gym.Api/Endpoints/LogEndpoints.cs
@@ -10,7 +10,8 @@ public static class LogEndpoints
 {
     public static RouteGroupBuilder MapLogEndpoints(this RouteGroupBuilder g)
     {
-        var group = g.MapGroup("logs").RequireAuthorization(Roles.ADMIN);
+        var group = g.MapGroup("logs")
+            .RequireAuthorization(p => p.RequireRole(Roles.ADMIN));
         group.MapGet("", async (ILogService svc) => Results.Ok(await svc.All()));
         group.MapGet("latest", async (ILogService svc) =>
             await svc.Latest() is { } dto ? Results.Ok(dto) : Results.NoContent());

--- a/src/Gym.Api/Endpoints/ReminderEndpoints.cs
+++ b/src/Gym.Api/Endpoints/ReminderEndpoints.cs
@@ -10,7 +10,8 @@ public static class ReminderEndpoints
 {
     public static RouteGroupBuilder MapReminderEndpoints(this RouteGroupBuilder g)
     {
-        var group = g.MapGroup("reminders").RequireAuthorization(Roles.ADMIN);
+        var group = g.MapGroup("reminders")
+            .RequireAuthorization(p => p.RequireRole(Roles.ADMIN));
 
         group.MapGet("tomorrow", async (IReminderService svc) =>
         {

--- a/src/Gym.Api/Endpoints/UserEndpoints.cs
+++ b/src/Gym.Api/Endpoints/UserEndpoints.cs
@@ -12,7 +12,8 @@ public static class UserEndpoints
 {
     public static RouteGroupBuilder MapUserEndpoints(this RouteGroupBuilder g)
     {
-        var group = g.MapGroup("users").RequireAuthorization(Roles.ADMIN);
+        var group = g.MapGroup("users")
+            .RequireAuthorization(p => p.RequireRole(Roles.ADMIN));
 
         group.MapGet("", async (IUserService svc) => Results.Ok(await svc.All()));
         group.MapGet("/{id:int}", async (int id, IUserService svc) =>

--- a/src/Gym.Api/Mapping/MappingProfile.cs
+++ b/src/Gym.Api/Mapping/MappingProfile.cs
@@ -40,6 +40,9 @@ public class MappingProfile : Profile
 
         CreateMap<EmailAlert, EmailAlertDto>()
             .ForCtorParam("Id", o => o.MapFrom(s => s.AlertId))
-            .ForCtorParam("AlertType", o => o.MapFrom(s => s.AlertType.ToString()));
+            .ForCtorParam("AlertType", o => o.MapFrom(s => s.AlertType.ToString()))
+            .ForCtorParam("MemberId", o => o.MapFrom(s => s.RelatedMember))
+            .ForCtorParam("Details", o => o.MapFrom(s => s.Details))
+            .ForCtorParam("SentAt", o => o.MapFrom(s => s.SentAt));
     }
 }

--- a/src/Gym.Api/Program.cs
+++ b/src/Gym.Api/Program.cs
@@ -34,6 +34,10 @@ builder.Services.AddHostedService<BackupService>();
 
 builder.Services.AddAuthorization();
 
+// return enums as strings for consistent client models
+builder.Services.ConfigureHttpJsonOptions(o =>
+    o.SerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter()));
+
 builder.Services.AddAutoMapper(typeof(Program));
 
 builder.Services.AddEndpointsApiExplorer();

--- a/src/Gym.Client/ApiClient.cs
+++ b/src/Gym.Client/ApiClient.cs
@@ -13,6 +13,11 @@ public class ApiClient
         _http = new HttpClient { BaseAddress = new(baseUrl) };
     }
 
+    public void Logout()
+    {
+        _http.DefaultRequestHeaders.Authorization = null;
+    }
+
     public record ApiResult(bool Success, string? Error);
 
     public async Task<ApiResult> LoginAsync(string user, string password)

--- a/src/Gym.Client/ApiClient.cs
+++ b/src/Gym.Client/ApiClient.cs
@@ -13,14 +13,46 @@ public class ApiClient
         _http = new HttpClient { BaseAddress = new(baseUrl) };
     }
 
-    public async Task<bool> LoginAsync(string user, string password)
+    public record ApiResult(bool Success, string? Error);
+
+    public async Task<ApiResult> LoginAsync(string user, string password)
     {
-        var resp = await _http.PostAsJsonAsync("api/auth/login", new { username = user, password });
-        if (!resp.IsSuccessStatusCode) return false;
-        var tok = await resp.Content.ReadFromJsonAsync<LoginResult>();
-        if (tok is null) return false;
-        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tok.Access);
-        return true;
+        try
+        {
+            var resp = await _http.PostAsJsonAsync("api/auth/login", new { username = user, password });
+            if (!resp.IsSuccessStatusCode)
+            {
+                var msg = await resp.Content.ReadAsStringAsync();
+                return new(false, string.IsNullOrWhiteSpace(msg) ? "Invalid credentials" : msg);
+            }
+            var tok = await resp.Content.ReadFromJsonAsync<LoginResult>();
+            if (tok is null)
+                return new(false, "Invalid response from server");
+            _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tok.Access);
+            return new(true, null);
+        }
+        catch (Exception ex)
+        {
+            return new(false, ex.Message);
+        }
+    }
+
+    public async Task<ApiResult> SignUpAsync(string user, string email, string password)
+    {
+        try
+        {
+            var resp = await _http.PostAsJsonAsync("api/auth/signup", new { username = user, email, password });
+            if (!resp.IsSuccessStatusCode)
+            {
+                var msg = await resp.Content.ReadAsStringAsync();
+                return new(false, string.IsNullOrWhiteSpace(msg) ? "Signup failed" : msg);
+            }
+            return new(true, null);
+        }
+        catch (Exception ex)
+        {
+            return new(false, ex.Message);
+        }
     }
 
     public Task<List<MemberDto>?> GetMembersAsync() =>

--- a/src/Gym.Client/App.xaml
+++ b/src/Gym.Client/App.xaml
@@ -4,6 +4,10 @@
              xmlns:local="clr-namespace:Gym.Client"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
-         
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Styles/Modern.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/Gym.Client/MainWindow.xaml
+++ b/src/Gym.Client/MainWindow.xaml
@@ -7,24 +7,26 @@
         mc:Ignorable="d"
         Title="Gym Client" Height="450" Width="800">
     <DockPanel>
-        <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Background="#333" Margin="0" Padding="5">
-            <StackPanel.Resources>
-                <Style TargetType="Button">
-                    <Setter Property="Foreground" Value="White"/>
-                    <Setter Property="Background" Value="Transparent"/>
-                    <Setter Property="BorderBrush" Value="Transparent"/>
-                    <Setter Property="Margin" Value="2"/>
-                </Style>
-            </StackPanel.Resources>
-            <Button x:Name="LoginBtn" Content="Login" Click="Login_Click" Margin="2"/>
-            <Button x:Name="DashboardBtn" Content="Dashboard" Click="Dashboard_Click" Margin="2"/>
-            <Button x:Name="MembersBtn" Content="Members" Click="Members_Click" Margin="2"/>
-            <Button x:Name="PlansBtn" Content="Plans" Click="Plans_Click" Margin="2"/>
-            <Button x:Name="UsersBtn" Content="Users" Click="Users_Click" Margin="2"/>
-            <Button x:Name="LogsBtn" Content="Logs" Click="Logs_Click" Margin="2"/>
-            <Button x:Name="RemindersBtn" Content="Reminders" Click="Reminders_Click" Margin="2"/>
-            <Button x:Name="AlertsBtn" Content="Alerts" Click="Alerts_Click" Margin="2"/>
-        </StackPanel>
+        <Border Background="#333" Padding="5" DockPanel.Dock="Top">
+            <StackPanel Orientation="Horizontal">
+                <StackPanel.Resources>
+                    <Style TargetType="Button">
+                        <Setter Property="Foreground" Value="White"/>
+                        <Setter Property="Background" Value="Transparent"/>
+                        <Setter Property="BorderBrush" Value="Transparent"/>
+                        <Setter Property="Margin" Value="2"/>
+                    </Style>
+                </StackPanel.Resources>
+                <Button x:Name="LoginBtn" Content="Login" Click="Login_Click" Margin="2"/>
+                <Button x:Name="DashboardBtn" Content="Dashboard" Click="Dashboard_Click" Margin="2"/>
+                <Button x:Name="MembersBtn" Content="Members" Click="Members_Click" Margin="2"/>
+                <Button x:Name="PlansBtn" Content="Plans" Click="Plans_Click" Margin="2"/>
+                <Button x:Name="UsersBtn" Content="Users" Click="Users_Click" Margin="2"/>
+                <Button x:Name="LogsBtn" Content="Logs" Click="Logs_Click" Margin="2"/>
+                <Button x:Name="RemindersBtn" Content="Reminders" Click="Reminders_Click" Margin="2"/>
+                <Button x:Name="AlertsBtn" Content="Alerts" Click="Alerts_Click" Margin="2"/>
+            </StackPanel>
+        </Border>
         <Frame x:Name="MainFrame"/>
     </DockPanel>
 </Window>

--- a/src/Gym.Client/MainWindow.xaml
+++ b/src/Gym.Client/MainWindow.xaml
@@ -10,12 +10,7 @@
         <Border Background="#333" Padding="5" DockPanel.Dock="Top">
             <StackPanel Orientation="Horizontal">
                 <StackPanel.Resources>
-                    <Style TargetType="Button">
-                        <Setter Property="Foreground" Value="White"/>
-                        <Setter Property="Background" Value="Transparent"/>
-                        <Setter Property="BorderBrush" Value="Transparent"/>
-                        <Setter Property="Margin" Value="2"/>
-                    </Style>
+                    <Style TargetType="Button" BasedOn="{StaticResource NavButtonStyle}" />
                 </StackPanel.Resources>
                 <Button x:Name="LoginBtn" Content="Login" Click="Login_Click" Margin="2"/>
                 <Button x:Name="DashboardBtn" Content="Dashboard" Click="Dashboard_Click" Margin="2"/>

--- a/src/Gym.Client/MainWindow.xaml
+++ b/src/Gym.Client/MainWindow.xaml
@@ -7,7 +7,15 @@
         mc:Ignorable="d"
         Title="Gym Client" Height="450" Width="800">
     <DockPanel>
-        <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Background="LightGray" Margin="5">
+        <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Background="#333" Margin="0" Padding="5">
+            <StackPanel.Resources>
+                <Style TargetType="Button">
+                    <Setter Property="Foreground" Value="White"/>
+                    <Setter Property="Background" Value="Transparent"/>
+                    <Setter Property="BorderBrush" Value="Transparent"/>
+                    <Setter Property="Margin" Value="2"/>
+                </Style>
+            </StackPanel.Resources>
             <Button x:Name="LoginBtn" Content="Login" Click="Login_Click" Margin="2"/>
             <Button x:Name="DashboardBtn" Content="Dashboard" Click="Dashboard_Click" Margin="2"/>
             <Button x:Name="MembersBtn" Content="Members" Click="Members_Click" Margin="2"/>

--- a/src/Gym.Client/MainWindow.xaml.cs
+++ b/src/Gym.Client/MainWindow.xaml.cs
@@ -19,6 +19,7 @@ public partial class MainWindow : Window
     private void SetLoggedIn(bool value)
     {
         _loggedIn = value;
+        LoginBtn.Content = value ? "Logout" : "Login";
         DashboardBtn.IsEnabled = value;
         MembersBtn.IsEnabled = value;
         PlansBtn.IsEnabled = value;
@@ -82,7 +83,17 @@ public partial class MainWindow : Window
 
     private void Login_Click(object sender, RoutedEventArgs e)
     {
-        ShowLogin();
+        if (_loggedIn)
+        {
+            // log out and return to login page
+            _api.Logout();
+            SetLoggedIn(false);
+            ShowLogin();
+        }
+        else
+        {
+            ShowLogin();
+        }
     }
 
 }

--- a/src/Gym.Client/MainWindow.xaml.cs
+++ b/src/Gym.Client/MainWindow.xaml.cs
@@ -12,7 +12,7 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
         SetLoggedIn(false);
-        MainFrame.Content = new LoginPage(_api, OnLoggedIn);
+        ShowLogin();
     }
 
 
@@ -32,6 +32,16 @@ public partial class MainWindow : Window
     {
         SetLoggedIn(true);
         MainFrame.Content = new DashboardPage(_api);
+    }
+
+    private void ShowLogin()
+    {
+        MainFrame.Content = new LoginPage(_api, OnLoggedIn, ShowSignup);
+    }
+
+    private void ShowSignup()
+    {
+        MainFrame.Content = new SignUpPage(_api, OnLoggedIn, ShowLogin);
     }
 
 
@@ -72,7 +82,7 @@ public partial class MainWindow : Window
 
     private void Login_Click(object sender, RoutedEventArgs e)
     {
-        MainFrame.Content = new LoginPage(_api, OnLoggedIn);
+        ShowLogin();
     }
 
 }

--- a/src/Gym.Client/Pages/AlertsPage.xaml
+++ b/src/Gym.Client/Pages/AlertsPage.xaml
@@ -8,6 +8,9 @@
         <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,5">
             <Button Content="Refresh" Click="Refresh_Click" Width="80"/>
         </StackPanel>
-        <DataGrid x:Name="Grid" AutoGenerateColumns="True"/>
+        <DataGrid x:Name="Grid" AutoGenerateColumns="True"
+                  VirtualizingPanel.IsVirtualizing="True"
+                  VirtualizingPanel.VirtualizationMode="Recycling"
+                  EnableRowVirtualization="True" EnableColumnVirtualization="True"/>
     </DockPanel>
 </Page>

--- a/src/Gym.Client/Pages/AlertsPage.xaml
+++ b/src/Gym.Client/Pages/AlertsPage.xaml
@@ -11,6 +11,7 @@
         <DataGrid x:Name="Grid" AutoGenerateColumns="True"
                   VirtualizingPanel.IsVirtualizing="True"
                   VirtualizingPanel.VirtualizationMode="Recycling"
-                  EnableRowVirtualization="True" EnableColumnVirtualization="True"/>
+                  EnableRowVirtualization="True" EnableColumnVirtualization="True"
+                  ContextMenu="{x:Null}"/>
     </DockPanel>
 </Page>

--- a/src/Gym.Client/Pages/AlertsPage.xaml.cs
+++ b/src/Gym.Client/Pages/AlertsPage.xaml.cs
@@ -15,6 +15,7 @@ public partial class AlertsPage : Page
         InitializeComponent();
         _api = api;
         Grid.ItemsSource = Items;
+        Loaded += Refresh_Click;
     }
 
     private async void Refresh_Click(object sender, RoutedEventArgs e)

--- a/src/Gym.Client/Pages/DashboardPage.xaml
+++ b/src/Gym.Client/Pages/DashboardPage.xaml
@@ -16,8 +16,14 @@
             <Button Content="Latest Access" Click="Latest_Click" Margin="10,0,0,0" Width="100"/>
         </StackPanel>
         <TextBlock Text="Late Members" FontWeight="Bold" Margin="5"/>
-        <DataGrid x:Name="LateGrid" Margin="5" AutoGenerateColumns="True"/>
+        <DataGrid x:Name="LateGrid" Margin="5" AutoGenerateColumns="True"
+                  VirtualizingPanel.IsVirtualizing="True"
+                  VirtualizingPanel.VirtualizationMode="Recycling"
+                  EnableRowVirtualization="True" EnableColumnVirtualization="True"/>
         <TextBlock Text="All Subscriptions" FontWeight="Bold" Margin="5"/>
-        <DataGrid x:Name="SubGrid" Margin="5" AutoGenerateColumns="True"/>
+        <DataGrid x:Name="SubGrid" Margin="5" AutoGenerateColumns="True"
+                  VirtualizingPanel.IsVirtualizing="True"
+                  VirtualizingPanel.VirtualizationMode="Recycling"
+                  EnableRowVirtualization="True" EnableColumnVirtualization="True"/>
     </DockPanel>
 </Page>

--- a/src/Gym.Client/Pages/DashboardPage.xaml
+++ b/src/Gym.Client/Pages/DashboardPage.xaml
@@ -19,11 +19,13 @@
         <DataGrid x:Name="LateGrid" Margin="5" AutoGenerateColumns="True"
                   VirtualizingPanel.IsVirtualizing="True"
                   VirtualizingPanel.VirtualizationMode="Recycling"
-                  EnableRowVirtualization="True" EnableColumnVirtualization="True"/>
+                  EnableRowVirtualization="True" EnableColumnVirtualization="True"
+                  ContextMenu="{x:Null}"/>
         <TextBlock Text="All Subscriptions" FontWeight="Bold" Margin="5"/>
         <DataGrid x:Name="SubGrid" Margin="5" AutoGenerateColumns="True"
                   VirtualizingPanel.IsVirtualizing="True"
                   VirtualizingPanel.VirtualizationMode="Recycling"
-                  EnableRowVirtualization="True" EnableColumnVirtualization="True"/>
+                  EnableRowVirtualization="True" EnableColumnVirtualization="True"
+                  ContextMenu="{x:Null}"/>
     </DockPanel>
 </Page>

--- a/src/Gym.Client/Pages/DashboardPage.xaml.cs
+++ b/src/Gym.Client/Pages/DashboardPage.xaml.cs
@@ -22,6 +22,7 @@ public partial class DashboardPage : Page
         DataContext = this;
         LateGrid.ItemsSource = LateItems;
         SubGrid.ItemsSource = SubItems;
+        Loaded += Refresh_Click;
     }
 
     private async void Refresh_Click(object sender, RoutedEventArgs e)

--- a/src/Gym.Client/Pages/LoginPage.xaml.cs
+++ b/src/Gym.Client/Pages/LoginPage.xaml.cs
@@ -8,25 +8,31 @@ public partial class LoginPage : Page
 {
     private readonly ApiClient _api;
     private readonly Action _onSuccess;
-    public LoginPage(ApiClient api, Action onSuccess)
+    private readonly Action _goSignup;
+    public LoginPage(ApiClient api, Action onSuccess, Action goSignup)
     {
         InitializeComponent();
         _api = api;
         _onSuccess = onSuccess;
+        _goSignup = goSignup;
     }
 
     private async void Login_Click(object sender, RoutedEventArgs e)
     {
-        ErrorText.Visibility = Visibility.Collapsed;
-        bool ok = await _api.LoginAsync(UserBox.Text, PwdBox.Password);
-        if (ok)
+        ErrorText.Text = string.Empty;
+        var result = await _api.LoginAsync(UserBox.Text, PwdBox.Password);
+        if (result.Success)
         {
             _onSuccess?.Invoke();
         }
         else
         {
-            ErrorText.Text = "Login failed";
-            ErrorText.Visibility = Visibility.Visible;
+            ErrorText.Text = result.Error ?? "Login failed";
         }
+    }
+
+    private void SignUp_Click(object sender, RoutedEventArgs e)
+    {
+        _goSignup?.Invoke();
     }
 }

--- a/src/Gym.Client/Pages/LogsPage.xaml
+++ b/src/Gym.Client/Pages/LogsPage.xaml
@@ -9,6 +9,7 @@
         <DataGrid x:Name="Grid" Margin="5" AutoGenerateColumns="True"
                   VirtualizingPanel.IsVirtualizing="True"
                   VirtualizingPanel.VirtualizationMode="Recycling"
-                  EnableRowVirtualization="True" EnableColumnVirtualization="True"/>
+                  EnableRowVirtualization="True" EnableColumnVirtualization="True"
+                  ContextMenu="{x:Null}"/>
     </DockPanel>
 </Page>

--- a/src/Gym.Client/Pages/LogsPage.xaml
+++ b/src/Gym.Client/Pages/LogsPage.xaml
@@ -6,6 +6,9 @@
         <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="5">
             <Button Content="Refresh" Click="Refresh_Click" Margin="2"/>
         </StackPanel>
-        <DataGrid x:Name="Grid" Margin="5" AutoGenerateColumns="True"/>
+        <DataGrid x:Name="Grid" Margin="5" AutoGenerateColumns="True"
+                  VirtualizingPanel.IsVirtualizing="True"
+                  VirtualizingPanel.VirtualizationMode="Recycling"
+                  EnableRowVirtualization="True" EnableColumnVirtualization="True"/>
     </DockPanel>
 </Page>

--- a/src/Gym.Client/Pages/LogsPage.xaml.cs
+++ b/src/Gym.Client/Pages/LogsPage.xaml.cs
@@ -15,6 +15,7 @@ public partial class LogsPage : Page
         InitializeComponent();
         _api = api;
         Grid.ItemsSource = Items;
+        Loaded += Refresh_Click;
     }
 
     private async void Refresh_Click(object sender, RoutedEventArgs e)

--- a/src/Gym.Client/Pages/MembersPage.xaml
+++ b/src/Gym.Client/Pages/MembersPage.xaml
@@ -15,6 +15,7 @@
         <DataGrid x:Name="Grid" Margin="5" AutoGenerateColumns="True"
                   VirtualizingPanel.IsVirtualizing="True"
                   VirtualizingPanel.VirtualizationMode="Recycling"
-                  EnableRowVirtualization="True" EnableColumnVirtualization="True"/>
+                  EnableRowVirtualization="True" EnableColumnVirtualization="True"
+                  ContextMenu="{x:Null}"/>
     </DockPanel>
 </Page>

--- a/src/Gym.Client/Pages/MembersPage.xaml
+++ b/src/Gym.Client/Pages/MembersPage.xaml
@@ -12,6 +12,9 @@
             <Button Content="Edit" Click="Edit_Click" Margin="2" />
             <Button Content="Delete" Click="Delete_Click" Margin="2" />
         </StackPanel>
-        <DataGrid x:Name="Grid" Margin="5" AutoGenerateColumns="True"/>
+        <DataGrid x:Name="Grid" Margin="5" AutoGenerateColumns="True"
+                  VirtualizingPanel.IsVirtualizing="True"
+                  VirtualizingPanel.VirtualizationMode="Recycling"
+                  EnableRowVirtualization="True" EnableColumnVirtualization="True"/>
     </DockPanel>
 </Page>

--- a/src/Gym.Client/Pages/MembersPage.xaml.cs
+++ b/src/Gym.Client/Pages/MembersPage.xaml.cs
@@ -16,6 +16,7 @@ public partial class MembersPage : Page
         InitializeComponent();
         _api = api;
         Grid.ItemsSource = Items;
+        Loaded += Refresh_Click;
     }
 
     private async void Refresh_Click(object sender, RoutedEventArgs e)

--- a/src/Gym.Client/Pages/PlansPage.xaml
+++ b/src/Gym.Client/Pages/PlansPage.xaml
@@ -15,6 +15,7 @@
         <DataGrid x:Name="Grid" Margin="5" AutoGenerateColumns="True"
                   VirtualizingPanel.IsVirtualizing="True"
                   VirtualizingPanel.VirtualizationMode="Recycling"
-                  EnableRowVirtualization="True" EnableColumnVirtualization="True"/>
+                  EnableRowVirtualization="True" EnableColumnVirtualization="True"
+                  ContextMenu="{x:Null}"/>
     </DockPanel>
 </Page>

--- a/src/Gym.Client/Pages/PlansPage.xaml
+++ b/src/Gym.Client/Pages/PlansPage.xaml
@@ -12,6 +12,9 @@
             <Button Content="Edit" Click="Edit_Click" Margin="2" />
             <Button Content="Delete" Click="Delete_Click" Margin="2" />
         </StackPanel>
-        <DataGrid x:Name="Grid" Margin="5" AutoGenerateColumns="True"/>
+        <DataGrid x:Name="Grid" Margin="5" AutoGenerateColumns="True"
+                  VirtualizingPanel.IsVirtualizing="True"
+                  VirtualizingPanel.VirtualizationMode="Recycling"
+                  EnableRowVirtualization="True" EnableColumnVirtualization="True"/>
     </DockPanel>
 </Page>

--- a/src/Gym.Client/Pages/PlansPage.xaml.cs
+++ b/src/Gym.Client/Pages/PlansPage.xaml.cs
@@ -16,6 +16,7 @@ public partial class PlansPage : Page
         InitializeComponent();
         _api = api;
         Grid.ItemsSource = Items;
+        Loaded += Refresh_Click;
     }
 
     private async void Refresh_Click(object sender, RoutedEventArgs e)

--- a/src/Gym.Client/Pages/RemindersPage.xaml
+++ b/src/Gym.Client/Pages/RemindersPage.xaml
@@ -10,6 +10,7 @@
         <DataGrid x:Name="Grid" Margin="5" AutoGenerateColumns="True"
                   VirtualizingPanel.IsVirtualizing="True"
                   VirtualizingPanel.VirtualizationMode="Recycling"
-                  EnableRowVirtualization="True" EnableColumnVirtualization="True"/>
+                  EnableRowVirtualization="True" EnableColumnVirtualization="True"
+                  ContextMenu="{x:Null}"/>
     </DockPanel>
 </Page>

--- a/src/Gym.Client/Pages/RemindersPage.xaml
+++ b/src/Gym.Client/Pages/RemindersPage.xaml
@@ -7,6 +7,9 @@
             <Button Content="Refresh" Click="Refresh_Click" Margin="2"/>
             <Button Content="Send Email" Click="Send_Click" Margin="2"/>
         </StackPanel>
-        <DataGrid x:Name="Grid" Margin="5" AutoGenerateColumns="True"/>
+        <DataGrid x:Name="Grid" Margin="5" AutoGenerateColumns="True"
+                  VirtualizingPanel.IsVirtualizing="True"
+                  VirtualizingPanel.VirtualizationMode="Recycling"
+                  EnableRowVirtualization="True" EnableColumnVirtualization="True"/>
     </DockPanel>
 </Page>

--- a/src/Gym.Client/Pages/RemindersPage.xaml.cs
+++ b/src/Gym.Client/Pages/RemindersPage.xaml.cs
@@ -16,6 +16,7 @@ public partial class RemindersPage : Page
         InitializeComponent();
         _api = api;
         Grid.ItemsSource = Items;
+        Loaded += Refresh_Click;
     }
 
     private async void Refresh_Click(object sender, RoutedEventArgs e)

--- a/src/Gym.Client/Pages/SignUpPage.xaml
+++ b/src/Gym.Client/Pages/SignUpPage.xaml
@@ -1,23 +1,31 @@
-<Page x:Class="Gym.Client.Pages.LoginPage"
+<Page x:Class="Gym.Client.Pages.SignUpPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      Title="Login">
+      Title="Sign Up">
     <Grid Background="#f0f0f0">
         <Border Width="300" Padding="20" Background="White" CornerRadius="8" HorizontalAlignment="Center" VerticalAlignment="Center">
             <StackPanel>
-                <TextBlock Text="Login" FontSize="20" FontWeight="Bold" Margin="0 0 0 10" HorizontalAlignment="Center"/>
+                <TextBlock Text="Sign Up" FontSize="20" FontWeight="Bold" Margin="0 0 0 10" HorizontalAlignment="Center"/>
                 <StackPanel Orientation="Horizontal" Margin="5">
                     <TextBlock Text="Username:" Width="80" VerticalAlignment="Center"/>
                     <TextBox x:Name="UserBox" Width="200"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="5">
+                    <TextBlock Text="Email:" Width="80" VerticalAlignment="Center"/>
+                    <TextBox x:Name="EmailBox" Width="200"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="5">
                     <TextBlock Text="Password:" Width="80" VerticalAlignment="Center"/>
                     <PasswordBox x:Name="PwdBox" Width="200"/>
                 </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="5">
+                    <TextBlock Text="Confirm:" Width="80" VerticalAlignment="Center"/>
+                    <PasswordBox x:Name="ConfirmBox" Width="200"/>
+                </StackPanel>
                 <TextBlock x:Name="ErrorText" Foreground="Red" Margin="5" TextWrapping="Wrap"/>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                    <Button Content="Sign Up" Margin="5" Click="SignUp_Click"/>
-                    <Button Content="Login" Width="80" Margin="5" Click="Login_Click"/>
+                    <Button Content="Back" Margin="5" Click="Back_Click"/>
+                    <Button Content="Sign Up" Width="80" Margin="5" Click="SignUp_Click"/>
                 </StackPanel>
             </StackPanel>
         </Border>

--- a/src/Gym.Client/Pages/SignUpPage.xaml.cs
+++ b/src/Gym.Client/Pages/SignUpPage.xaml.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Gym.Client.Pages;
+
+public partial class SignUpPage : Page
+{
+    private readonly ApiClient _api;
+    private readonly Action _onSuccess;
+    private readonly Action _goLogin;
+    public SignUpPage(ApiClient api, Action onSuccess, Action goLogin)
+    {
+        InitializeComponent();
+        _api = api;
+        _onSuccess = onSuccess;
+        _goLogin = goLogin;
+    }
+
+    private async void SignUp_Click(object sender, RoutedEventArgs e)
+    {
+        ErrorText.Text = string.Empty;
+        if (PwdBox.Password != ConfirmBox.Password)
+        {
+            ErrorText.Text = "Passwords do not match";
+            return;
+        }
+        var result = await _api.SignUpAsync(UserBox.Text, EmailBox.Text, PwdBox.Password);
+        if (result.Success)
+        {
+            _onSuccess?.Invoke();
+        }
+        else
+        {
+            ErrorText.Text = result.Error ?? "Signup failed";
+        }
+    }
+
+    private void Back_Click(object sender, RoutedEventArgs e)
+    {
+        _goLogin?.Invoke();
+    }
+}

--- a/src/Gym.Client/Pages/UsersPage.xaml
+++ b/src/Gym.Client/Pages/UsersPage.xaml
@@ -16,6 +16,7 @@
         <DataGrid x:Name="Grid" Margin="5" AutoGenerateColumns="True"
                   VirtualizingPanel.IsVirtualizing="True"
                   VirtualizingPanel.VirtualizationMode="Recycling"
-                  EnableRowVirtualization="True" EnableColumnVirtualization="True"/>
+                  EnableRowVirtualization="True" EnableColumnVirtualization="True"
+                  ContextMenu="{x:Null}"/>
     </DockPanel>
 </Page>

--- a/src/Gym.Client/Pages/UsersPage.xaml
+++ b/src/Gym.Client/Pages/UsersPage.xaml
@@ -13,6 +13,9 @@
         </StackPanel>
         <TextBlock Text="Active Users:" Margin="5"/>
         <TextBlock x:Name="ActiveText" Margin="5"/>
-        <DataGrid x:Name="Grid" Margin="5" AutoGenerateColumns="True"/>
+        <DataGrid x:Name="Grid" Margin="5" AutoGenerateColumns="True"
+                  VirtualizingPanel.IsVirtualizing="True"
+                  VirtualizingPanel.VirtualizationMode="Recycling"
+                  EnableRowVirtualization="True" EnableColumnVirtualization="True"/>
     </DockPanel>
 </Page>

--- a/src/Gym.Client/Pages/UsersPage.xaml.cs
+++ b/src/Gym.Client/Pages/UsersPage.xaml.cs
@@ -17,6 +17,7 @@ public partial class UsersPage : Page
         InitializeComponent();
         _api = api;
         Grid.ItemsSource = Items;
+        Loaded += Refresh_Click;
     }
 
     private async void Refresh_Click(object sender, RoutedEventArgs e)

--- a/src/Gym.Client/Styles/Modern.xaml
+++ b/src/Gym.Client/Styles/Modern.xaml
@@ -1,6 +1,8 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Color x:Key="AccentColor">#0078D7</Color>
+    <!-- Brush version of the accent color so it can be used where a Brush is required -->
+    <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}" />
     <Style TargetType="Window">
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="14" />
@@ -8,8 +10,9 @@
     </Style>
     <Style TargetType="Button">
         <Setter Property="Foreground" Value="White" />
-        <Setter Property="Background" Value="{StaticResource AccentColor}" />
-        <Setter Property="BorderBrush" Value="{StaticResource AccentColor}" />
+        <!-- Use the brush resource so controls expecting a Brush can resolve correctly -->
+        <Setter Property="Background" Value="{StaticResource AccentBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource AccentBrush}" />
         <Setter Property="Padding" Value="8,4" />
         <Setter Property="Margin" Value="2" />
         <Setter Property="BorderThickness" Value="1" />

--- a/src/Gym.Client/Styles/Modern.xaml
+++ b/src/Gym.Client/Styles/Modern.xaml
@@ -1,8 +1,10 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Color x:Key="AccentColor">#0078D7</Color>
+    <Color x:Key="AccentHoverColor">#3399FF</Color>
     <!-- Brush version of the accent color so it can be used where a Brush is required -->
     <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}" />
+    <SolidColorBrush x:Key="AccentHoverBrush" Color="{StaticResource AccentHoverColor}" />
     <Style TargetType="Window">
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="14" />
@@ -19,13 +21,22 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
-                    <Border Background="{TemplateBinding Background}"
+                    <Border x:Name="Bd" Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
                             CornerRadius="4"
                             Padding="{TemplateBinding Padding}">
                         <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
                     </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Bd" Property="Background" Value="{StaticResource AccentHoverBrush}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="Bd" Property="Background" Value="#CCC"/>
+                            <Setter Property="Foreground" Value="#666"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/src/Gym.Client/Styles/Modern.xaml
+++ b/src/Gym.Client/Styles/Modern.xaml
@@ -41,6 +41,12 @@
             </Setter.Value>
         </Setter>
     </Style>
+    <!-- Navigation buttons on the dark header -->
+    <Style x:Key="NavButtonStyle" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="Foreground" Value="White" />
+    </Style>
     <Style TargetType="DataGrid">
         <Setter Property="RowBackground" Value="White" />
         <Setter Property="AlternatingRowBackground" Value="#F3F3F3" />

--- a/src/Gym.Client/Styles/Modern.xaml
+++ b/src/Gym.Client/Styles/Modern.xaml
@@ -1,0 +1,23 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Color x:Key="AccentColor">#0078D7</Color>
+    <Style TargetType="Window">
+        <Setter Property="FontFamily" Value="Segoe UI" />
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="Background" Value="White" />
+    </Style>
+    <Style TargetType="Button">
+        <Setter Property="Foreground" Value="White" />
+        <Setter Property="Background" Value="{StaticResource AccentColor}" />
+        <Setter Property="BorderBrush" Value="{StaticResource AccentColor}" />
+        <Setter Property="Padding" Value="8,4" />
+        <Setter Property="Margin" Value="2" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CornerRadius" Value="4" />
+    </Style>
+    <Style TargetType="DataGrid">
+        <Setter Property="RowBackground" Value="White" />
+        <Setter Property="AlternatingRowBackground" Value="#F3F3F3" />
+        <Setter Property="GridLinesVisibility" Value="None" />
+    </Style>
+</ResourceDictionary>

--- a/src/Gym.Client/Styles/Modern.xaml
+++ b/src/Gym.Client/Styles/Modern.xaml
@@ -13,7 +13,19 @@
         <Setter Property="Padding" Value="8,4" />
         <Setter Property="Margin" Value="2" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="CornerRadius" Value="4" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="4"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
     <Style TargetType="DataGrid">
         <Setter Property="RowBackground" Value="White" />


### PR DESCRIPTION
## Summary
- support password validation using BCrypt and allow new users to sign up
- expose a public signup endpoint in API
- return descriptive errors from `ApiClient` on login or signup
- redesign login view and add signup view
- update main window styles for a modern look

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68746171cdb48325af4b2099d7aac6b8